### PR TITLE
Fix inverted arguments in CGlobalShortcutsPortal::onListShortcuts

### DIFF
--- a/src/portals/GlobalShortcuts.cpp
+++ b/src/portals/GlobalShortcuts.cpp
@@ -130,7 +130,7 @@ dbUasv CGlobalShortcutsPortal::onBindShortcuts(sdbus::ObjectPath requestHandle, 
     return {0, data};
 }
 
-dbUasv CGlobalShortcutsPortal::onListShortcuts(sdbus::ObjectPath sessionHandle, sdbus::ObjectPath requestHandle) {
+dbUasv CGlobalShortcutsPortal::onListShortcuts(sdbus::ObjectPath requestHandle, sdbus::ObjectPath sessionHandle) {
     Debug::log(LOG, "[globalshortcuts] List keys:");
     Debug::log(LOG, "[globalshortcuts]  | {}", sessionHandle.c_str());
 


### PR DESCRIPTION
The D-Bus call for ListShortcuts flat out fails/doesn't work in any scenario.
The spec states, and testing confirms, that the implementation has [requestHandle *then* sessionHandle passed](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.impl.portal.GlobalShortcuts.html#org-freedesktop-impl-portal-globalshortcuts-listshortcuts). This is the same for all other implemented methods, including the ones in this very file.

This code is entirely untested and has been brought to you by the GitHub web editor, though the issue is very obvious and my experimentation with a spec-conforming XDG portal D-Bus client confirms the issue.
![image](https://github.com/user-attachments/assets/de8e95f3-48d5-4b85-abdf-f0d69342c141)

As an aside, I suspect (but haven't confirmed because of this simple issue breaking my test case I am too lazy to fix for this simple issue) there exists an issue with `m_vSessions`. This vector is not cleared of a session whenever the session is closed, so if you close an app and re-open it, creating a new session, I suspect there will be duplication in `m_vSessions` causing `getShortcutById` to grab a stale shortcut, preventing the app from registering shortcuts under those IDs and polluting the Hyprland shortcut objects.